### PR TITLE
Update aiohttp version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "aiohttp==3.8.1",
+    "aiohttp==3.8.3",
     "python-dateutil==2.8.2"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "aiohttp==3.8.0",
+    "aiohttp==3.8.1",
     "python-dateutil==2.8.2"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiohttp==3.8.2
+aiohttp==3.8.3
 sphinx==5.2.3
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiohttp==3.8.0
+aiohttp==3.8.2
 sphinx==5.2.3
 python-dateutil==2.8.2


### PR DESCRIPTION
Aiohttp version 3.8.0 doesn't work on Python 3.11 so I updated it.